### PR TITLE
Fix branch deletion in orchestrator

### DIFF
--- a/git_operations.py
+++ b/git_operations.py
@@ -172,29 +172,22 @@ class GitOperations:
             return True
             
         try:
-            # Merge the PR directly (without --auto which requires special GitHub settings)
+            # Merge the PR and delete the branch in one command
             self.logger.info(f"Merging PR #{pr_number}...")
+            merge_cmd = ["gh", "pr", "merge", pr_number, "--merge"]
+            if delete_branch:
+                merge_cmd.append("--delete-branch")
+                self.logger.info("Will delete branch after merge")
+            
             merge_result = subprocess.run(
-                ["gh", "pr", "merge", pr_number, "--merge"],
+                merge_cmd,
                 capture_output=True,
                 text=True,
                 check=True
             )
             self.logger.info(f"PR #{pr_number} merged successfully")
-            
             if delete_branch:
-                # Delete the remote branch after merge
-                self.logger.info("Deleting merged branch...")
-                delete_result = subprocess.run(
-                    ["gh", "pr", "merge", pr_number, "--delete-branch"],
-                    capture_output=True,
-                    text=True,
-                    check=False  # Don't fail if branch is already deleted
-                )
-                if delete_result.returncode == 0:
-                    self.logger.info("Remote branch deleted successfully")
-                else:
-                    self.logger.warning("Could not delete remote branch (may already be deleted)")
+                self.logger.info("Remote branch deleted successfully")
                     
                 # Also delete local branch
                 current_branch = self.get_current_branch()


### PR DESCRIPTION
## Description
This PR fixes a bug in the orchestrator where branch deletion was failing after PR merge.

## Problem
The orchestrator was using two separate `gh pr merge` commands:
1. First to merge the PR
2. Second to delete the branch (which failed because PR was already merged)

## Solution
Combined the merge and branch deletion into a single command using `--merge --delete-branch` flags together.

## Changes
- Modified `merge_pull_request()` in `git_operations.py` to use single command
- Removed redundant second merge attempt

## Testing
Tested with `python orchestrator.py user-login` - branch was successfully deleted after merge.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>